### PR TITLE
Fix parser for msgTrail to not skip over line endings

### DIFF
--- a/irc-bytestring.cabal
+++ b/irc-bytestring.cabal
@@ -1,5 +1,5 @@
 Name: irc-bytestring
-Version: 0.1
+Version: 0.1.1
 Cabal-Version: >= 1.6
 License: BSD3
 License-File: LICENSE

--- a/src/Network/IRC/ByteString/Parser.hs
+++ b/src/Network/IRC/ByteString/Parser.hs
@@ -10,6 +10,7 @@ module Network.IRC.ByteString.Parser
 import Control.Applicative
 import Data.Attoparsec.Char8 as Char8
 import qualified Data.Attoparsec as Word8
+import qualified Data.Attoparsec.Text as T
 import Data.ByteString.Char8 as BS
   (cons, append, intercalate, ByteString, null, concat, pack, unpack)
 import Data.Maybe (fromMaybe)
@@ -129,7 +130,7 @@ params = fromMaybe [] <$> optional
                 <$> satisfy (\c -> isNonWhite c && c /= ':')
                 <*> Char8.takeWhile isNonWhite
 
-mess = spaces >> fromMaybe "" <$> 
+mess = many (satisfy (\c -> isSpace c && not (T.isEndOfLine c))) >> fromMaybe "" <$>
        optional (char ':' >> Word8.takeWhile (not . isEndOfLine))
        <?> "message body"
 


### PR DESCRIPTION
Before the `ircLine` parser parsed this:

```
":test 001 par1 par2\r\n:test 002 par1 par2 :trail\r\n"
```

to

```
IRCMsg { ... , msgTrail = "irc.test 002 par1 par2 :trail" }
```

instead of two separate messages.
